### PR TITLE
Bug fix: old config and old command doesn't work for new v2ray

### DIFF
--- a/config/server/dynamic/http.json
+++ b/config/server/dynamic/http.json
@@ -106,12 +106,7 @@
 			"protocol": "blackhole",
 			"settings": {},
 			"tag": "blocked"
-        },
-		{
-			"protocol": "mtproto",
-			"settings": {},
-			"tag": "tg-out"
-		}
+        }
 		//include_out_config
 		//
 	],

--- a/config/server/dynamic/kcp.json
+++ b/config/server/dynamic/kcp.json
@@ -78,12 +78,7 @@
 			"protocol": "blackhole",
 			"settings": {},
 			"tag": "blocked"
-        },
-		{
-			"protocol": "mtproto",
-			"settings": {},
-			"tag": "tg-out"
-		}
+        }
 		//include_out_config
 		//
 	],

--- a/config/server/dynamic/quic.json
+++ b/config/server/dynamic/quic.json
@@ -80,12 +80,7 @@
 			"protocol": "blackhole",
 			"settings": {},
 			"tag": "blocked"
-        },
-		{
-			"protocol": "mtproto",
-			"settings": {},
-			"tag": "tg-out"
-		}
+        }
 		//include_out_config
 		//
 	],

--- a/config/server/dynamic/tcp.json
+++ b/config/server/dynamic/tcp.json
@@ -65,12 +65,7 @@
 			"protocol": "blackhole",
 			"settings": {},
 			"tag": "blocked"
-        },
-		{
-			"protocol": "mtproto",
-			"settings": {},
-			"tag": "tg-out"
-		}
+        }
 		//include_out_config
 		//
 	],

--- a/config/server/dynamic/ws.json
+++ b/config/server/dynamic/ws.json
@@ -68,12 +68,7 @@
 			"protocol": "blackhole",
 			"settings": {},
 			"tag": "blocked"
-        },
-		{
-			"protocol": "mtproto",
-			"settings": {},
-			"tag": "tg-out"
-		}
+        }
 		//include_out_config
 		//
 	],

--- a/config/server/h2.json
+++ b/config/server/h2.json
@@ -61,12 +61,7 @@
 			"protocol": "blackhole",
 			"settings": {},
 			"tag": "blocked"
-        },
-		{
-			"protocol": "mtproto",
-			"settings": {},
-			"tag": "tg-out"
-		}
+        }
 		//include_out_config
 		//
 	],

--- a/config/server/http.json
+++ b/config/server/http.json
@@ -79,12 +79,7 @@
 			"protocol": "blackhole",
 			"settings": {},
 			"tag": "blocked"
-        },
-		{
-			"protocol": "mtproto",
-			"settings": {},
-			"tag": "tg-out"
-		}
+        }
 		//include_out_config
 		//
 	],

--- a/config/server/kcp.json
+++ b/config/server/kcp.json
@@ -51,12 +51,7 @@
 			"protocol": "blackhole",
 			"settings": {},
 			"tag": "blocked"
-        },
-		{
-			"protocol": "mtproto",
-			"settings": {},
-			"tag": "tg-out"
-		}
+        }
 		//include_out_config
 		//
 	],

--- a/config/server/quic.json
+++ b/config/server/quic.json
@@ -52,12 +52,7 @@
 			"protocol": "blackhole",
 			"settings": {},
 			"tag": "blocked"
-        },
-		{
-			"protocol": "mtproto",
-			"settings": {},
-			"tag": "tg-out"
-		}
+        }
 		//include_out_config
 		//
 	],

--- a/config/server/tcp.json
+++ b/config/server/tcp.json
@@ -46,12 +46,7 @@
 			"protocol": "blackhole",
 			"settings": {},
 			"tag": "blocked"
-        },
-		{
-			"protocol": "mtproto",
-			"settings": {},
-			"tag": "tg-out"
-		}
+        }
 		//include_out_config
 		//
 	],

--- a/config/server/vless_ws.json
+++ b/config/server/vless_ws.json
@@ -48,12 +48,7 @@
 			"protocol": "blackhole",
 			"settings": {},
 			"tag": "blocked"
-        },
-		{
-			"protocol": "mtproto",
-			"settings": {},
-			"tag": "tg-out"
-		}
+        }
 		//include_out_config
 		//
 	],

--- a/config/server/ws.json
+++ b/config/server/ws.json
@@ -46,12 +46,7 @@
 			"protocol": "blackhole",
 			"settings": {},
 			"tag": "blocked"
-        },
-		{
-			"protocol": "mtproto",
-			"settings": {},
-			"tag": "tg-out"
-		}
+        }
 		//include_out_config
 		//
 	],

--- a/src/download-v2ray.sh
+++ b/src/download-v2ray.sh
@@ -53,7 +53,7 @@ User=root
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
 NoNewPrivileges=true
-ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/config.json
+ExecStart=/usr/bin/v2ray/v2ray run -c /etc/v2ray/config.json
 #Restart=on-failure
 Restart=always
 


### PR DESCRIPTION
This PR fixes the following bugs:
1. outdated command. `v2ray -config xxx` should be updated to `v2ray run -c xxx`
2. outdated config. There is no outbound protocol mtproto in v4, causing crash.